### PR TITLE
add missing import statements

### DIFF
--- a/SwiftySandboxFileAccess/Classes/SandboxFileAccess.swift
+++ b/SwiftySandboxFileAccess/Classes/SandboxFileAccess.swift
@@ -1,3 +1,5 @@
+import AppKit
+
 //backwards compatibility with AppSandboxFileAccess
 public typealias AppSandboxFileAccess = SandboxFileAccess
 public typealias AppSandboxFileAccessProtocol = SandboxFileAccessProtocol

--- a/SwiftySandboxFileAccess/Classes/SandboxFileAccessPersist.swift
+++ b/SwiftySandboxFileAccess/Classes/SandboxFileAccessPersist.swift
@@ -30,6 +30,8 @@
 //  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
+import Foundation
+
 public class SandboxFileAccessPersist: SandboxFileAccessProtocol {
     
     public func bookmarkData(for url: URL) -> Data? {


### PR DESCRIPTION
When using the .swift files outside of CocoaPods, some import statements were missing.